### PR TITLE
Ignore files generated when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ Gemfile.lock
 .rspec_status
 
 # tests output
+node_modules/
+package.json
 spec/tmp/
+yarn.lock


### PR DESCRIPTION
# Summary

After running tests, some files are generated because of `yarn add htmx.org` command in [the generator](https://github.com/rootstrap/htmx-rails/blob/master/lib/generators/htmx/install_generator.rb#L41).
This files should be ignored, so git do not track them.