### PR TITLE
Remove $ from README and update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,31 @@
 
 ## Installation
 
+### Gem installation
+
 Add `htmx-rails` to your `Gemfile`:
 
 ```ruby
 gem 'htmx-rails'
 ```
 
-And then execute:
+And then execute in your shell:
 
-    $ bundle install
+```
+bundle install
+```
 
-Or install it yourself as:
+Or install it yourself by executing:
 
-    $ gem install htmx-rails
+```
+gem install htmx-rails
+```
 
-After installing the gem, run the installer:
+### After installing the gem, run the installer:
 
-    $ rails g htmx:install
+```
+rails g htmx:install
+```
 
 ## Usage
 


### PR DESCRIPTION
I removed the $ before the commands from the README so they can be copy-pasted easily and added some headings.